### PR TITLE
Only alter slug on edit-tags page when alternate sources avail.

### DIFF
--- a/inc/admin/class-term.php
+++ b/inc/admin/class-term.php
@@ -136,8 +136,8 @@ class Term extends Base {
 
 			$slug .= '<strong>' . esc_html( sprintf( __( ' - Synced from %s', 'extendable-aggregator' ), $blog_info->blogname ) ) . '</strong>';
 		}
-		
-		if ( $this->get_alternative_sources( $term->term_id ) ) {
+
+		if ( is_admin() && 'edit-tags' === $screen->base && $this->get_alternative_sources( $term->term_id ) ) {
 			$slug .= '<strong>' . esc_html(  __( ' - Alternative sources available', 'extendable-aggregator' ) ) . '</strong>';
 		}
 


### PR DESCRIPTION
The phrase `- Alternative sources available' was getting added to the slug when editing terms. While not a bad thing initially, if you save the slug without noticing, well - you get a new slug.

Looking at it, the original intention was only to display the source availability on edit-tags page. This PR resolves that.

_before_
![](http://caught-by-tarei.s3.amazonaws.com/LzHmUjn4.png)

_after_
![](http://caught-by-tarei.s3.amazonaws.com/iCZDPB2C.png)

![](http://caught-by-tarei.s3.amazonaws.com/EXchWorP.png) Still visible on edit-tags admin page.