### PR TITLE
8 fix term syncing not scheduled

### DIFF
--- a/extendable-aggregator.php
+++ b/extendable-aggregator.php
@@ -3,7 +3,7 @@
 Plugin name: Extendable Aggregator
 Description: Aggregates articles across multisite install
 Author: Human Made Limited
-Version: 1.0.0
+Version: 1.0.1
 */
 
 namespace EA;

--- a/inc/syncable/class-term.php
+++ b/inc/syncable/class-term.php
@@ -19,7 +19,7 @@ class Term extends Base {
 	/**
 	 * @public array $sync_hooks The actions/filters uses to trigger syncing of a syncable object
 	 */
-	public static $sync_hooks = [ 'create_term', 'edit_term' ];
+	public static $sync_hooks = [ 'created_term', 'edited_term' ];
 
 	/**
 	 * @public array $delete_hooks The actions/filters used to trigger deleting of a synced object


### PR DESCRIPTION
Use hooks that fire after term cache has been cleaned so that term syncing is scheduled immediately. Fixes #8.